### PR TITLE
Standardize imports and improve evaluation configuration

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -23,21 +23,25 @@ search_space:
 
 # Data config
 data:
-  path: data\processed\train.parquet
+  path: data/processed/train.parquet
   target: Survived
 
 # Training config
 training:
   test_size: 0.1
   n_trials: 20
+  random_state: 42
 
 split:
   data_path: data/raw/Titanic-Dataset.csv
   target_col: Survived
   test_size: 0.2
+  random_state: 42
 
 evaluation:
   model_path: models/model_pipeline.pkl
-  test_data_path: data\processed\test.parquet
+  test_data_path: data/processed/test.parquet
   target_col: Survived
   report_path: reports/evaluation_report.json
+  registry_stage: champion1
+  registry_model_name: Titanic_Classifier_Model

--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -1,5 +1,8 @@
 import os
 import json
+from pathlib import Path
+
+import joblib
 import pandas as pd
 import dvc.api
 import mlflow
@@ -7,7 +10,7 @@ import dagshub
 from dotenv import load_dotenv
 from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score, confusion_matrix
 
-from logger import get_logger
+from src.logger import get_logger
 
 logger = get_logger(__name__)
 
@@ -17,16 +20,42 @@ def setup_mlflow(cfg):
     logger.info("MLflow client initialized.")
     return client
 
+def load_model(cfg):
+    registry_model_name = cfg.get("registry_model_name", "Titanic_Classifier_Model")
+    registry_stage = cfg.get("registry_stage")
+
+    if registry_stage:
+        model_uri = f"models:/{registry_model_name}@{registry_stage}"
+        logger.info(f"Loading model from MLflow Registry at {model_uri}...")
+        try:
+            model = mlflow.sklearn.load_model(model_uri)
+            return model, model_uri
+        except Exception as exc:
+            logger.warning(
+                "Failed to load model from MLflow registry (%s). Falling back to local model if available. Error: %s",
+                model_uri,
+                exc,
+            )
+
+    model_path = cfg.get("model_path")
+    if model_path:
+        local_path = Path(model_path)
+        logger.info(f"Loading model from local path: {local_path.resolve()}")
+        model = joblib.load(local_path)
+        return model, str(local_path)
+
+    raise ValueError("No valid model source configured. Provide 'registry_stage' or 'model_path'.")
+
+
 def evaluate(client, cfg):
     logger.info("Loading test data...")
-    test_df = pd.read_parquet(cfg["test_data_path"])
+    test_data_path = Path(cfg["test_data_path"])
+    test_df = pd.read_parquet(test_data_path)
     y_test = test_df[cfg["target_col"]]
     X_test = test_df.drop(columns=[cfg["target_col"]])
 
-    logger.info(f"Loading model from MLflow Registry...")
-    model_uri = "models:/Titanic_Classifier_Model@champion1"
-    model = mlflow.sklearn.load_model(model_uri)
-    logger.info(f"Model loaded from URI: {model_uri}")
+    model, model_source = load_model(cfg)
+    logger.info(f"Model loaded from: {model_source}")
     preds = model.predict(X_test)
 
     acc = accuracy_score(y_test, preds)
@@ -44,11 +73,12 @@ def evaluate(client, cfg):
         "confusion_matrix": cm
     }
 
-    os.makedirs(os.path.dirname(cfg["report_path"]), exist_ok=True)
-    with open(cfg["report_path"], "w") as f:
+    report_path = Path(cfg["report_path"])
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    with report_path.open("w") as f:
         json.dump(report, f, indent=2)
 
-    logger.info(f"Evaluation report saved to {cfg['report_path']}")
+    logger.info(f"Evaluation report saved to {report_path}")
 
 if __name__ == "__main__":
     logger.info("Starting evaluation...")

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -2,7 +2,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.ensemble import RandomForestClassifier
 from xgboost import XGBClassifier
 from lightgbm import LGBMClassifier
-from preprocess import build_preprocessor
+from src.preprocess import build_preprocessor
 
 def build_pipeline(model_name="random_forest", model_params: dict = None):
     if model_params is None:

--- a/src/split_data.py
+++ b/src/split_data.py
@@ -1,9 +1,10 @@
-import os
+from pathlib import Path
+
 import pandas as pd
-import yaml
 import dvc.api
 from sklearn.model_selection import train_test_split
-from logger import get_logger
+
+from src.logger import get_logger
 
 logger = get_logger(__name__)
 
@@ -11,23 +12,30 @@ def split_and_save(params):
 
     
     split_cfg = params["split"]
-    data_path = split_cfg["data_path"]
+    data_path = Path(split_cfg["data_path"])
     target_col = split_cfg["target_col"]
     test_size = split_cfg["test_size"]
+    seed = split_cfg.get("random_state", 42)
 
 
     df = pd.read_csv(data_path)
     y = df[target_col]
     X = df.drop(columns=[target_col])
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=test_size)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X,
+        y,
+        test_size=test_size,
+        random_state=seed
+    )
 
 
     train_df = pd.concat([X_train, y_train.rename(target_col)], axis=1)
     test_df = pd.concat([X_test, y_test.rename(target_col)], axis=1)
 
-    os.makedirs("data/processed", exist_ok=True)
-    train_df.to_parquet("data/processed/train.parquet", index=False)
-    test_df.to_parquet("data/processed/test.parquet", index=False)
+    processed_dir = Path("data") / "processed"
+    processed_dir.mkdir(parents=True, exist_ok=True)
+    train_df.to_parquet(processed_dir / "train.parquet", index=False)
+    test_df.to_parquet(processed_dir / "test.parquet", index=False)
 
     logger.info("Train/Test data saved in data/processed/")
 

--- a/src/train.py
+++ b/src/train.py
@@ -10,8 +10,8 @@ from dotenv import load_dotenv
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score
 
-from pipeline import build_pipeline
-from logger import get_logger
+from src.pipeline import build_pipeline
+from src.logger import get_logger
 import dagshub
 
 # ================== Setup ====================


### PR DESCRIPTION
## Summary
- update internal imports to use the package-qualified `src.` module path
- make data paths and split parameters platform independent and reproducible
- allow evaluation to load models from a configurable MLflow stage or local artifact

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_690be49cc050832a8464ffc06db2dc7e